### PR TITLE
refactor remove gulp-util dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.10
+  - 6
 
 script:
   - npm test

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
   },
   "dependencies": {
     "bufferstreams": "^1.0.2",
-    "gulp-util": "^3.0.6",
+    "plugin-error": "^0.1.2",
     "readable-stream": "^2.0.1",
+    "replace-ext": "^1.0.0",
     "ttf2woff": "^2.0.1"
   },
   "keywords": [
@@ -45,11 +46,13 @@
     "converter"
   ],
   "devDependencies": {
+    "cloneable-readable": "^1.0.0",
     "coveralls": "^2.11.2",
     "gulp": "^3.9.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.4.2",
     "mocha-lcov-reporter": "^1.3.0",
-    "streamtest": "^1.2.1"
+    "streamtest": "^1.2.1",
+    "vinyl": "^2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "main": "src/index.js",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 6.11.1"
   },
   "scripts": {
     "test": "mocha tests/*.mocha.js",
@@ -30,9 +30,9 @@
     "cover": "./node_modules/istanbul/lib/cli.js cover --report html ./node_modules/mocha/bin/_mocha -- tests/*.mocha.js -R spec -t 5000"
   },
   "dependencies": {
-    "bufferstreams": "^1.0.2",
+    "bufferstreams": "^1.1.0",
     "plugin-error": "^0.1.2",
-    "readable-stream": "^2.0.1",
+    "readable-stream": "^2.0.4",
     "replace-ext": "^1.0.0",
     "ttf2woff": "^2.0.1"
   },
@@ -47,7 +47,7 @@
   ],
   "devDependencies": {
     "cloneable-readable": "^1.0.0",
-    "coveralls": "^2.11.2",
+    "coveralls": "^2.11.4",
     "gulp": "^3.9.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.4.2",

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,9 @@
 
 var path = require('path');
 var Stream = require('readable-stream');
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
 var BufferStreams = require('bufferstreams');
+var replaceExtension = require('replace-ext');
 var ttf2woff = require('ttf2woff');
 
 var PLUGIN_NAME = 'gulp-ttf2woff';
@@ -15,7 +16,7 @@ function ttf2woffTransform(opt) {
 
     // Handle any error
     if(err) {
-      cb(new gutil.PluginError(PLUGIN_NAME, err, {showStack: true}));
+      cb(new PluginError(PLUGIN_NAME, err, {showStack: true}));
     }
 
     // Use the buffered content
@@ -23,7 +24,7 @@ function ttf2woffTransform(opt) {
         buf = new Buffer(ttf2woff(new Uint8Array(buf)).buffer);
         cb(null, buf);
       } catch(err2) {
-        cb(new gutil.PluginError(PLUGIN_NAME, err2, {showStack: true}));
+        cb(new PluginError(PLUGIN_NAME, err2, {showStack: true}));
       }
 
   };
@@ -66,7 +67,7 @@ function ttf2woffGulp(options) {
       }
     }
 
-    file.path = gutil.replaceExtension(file.path, ".woff");
+    file.path = replaceExtension(file.path, ".woff");
 
     // Buffers
     if(file.isBuffer()) {
@@ -75,7 +76,7 @@ function ttf2woffGulp(options) {
           new Uint8Array(file.contents)
         ).buffer);
       } catch(err) {
-        stream.emit('error', new gutil.PluginError(PLUGIN_NAME, err, {
+        stream.emit('error', new PluginError(PLUGIN_NAME, err, {
           showStack: true
         }));
       }

--- a/tests/index.mocha.js
+++ b/tests/index.mocha.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var gulp = require('gulp');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
+var Cloneable = require('cloneable-readable');
 var Stream = require('stream');
 var fs = require('fs');
 
@@ -23,7 +24,7 @@ describe('gulp-ttf2woff conversion', function() {
 
         it('should let null files pass through', function(done) {
 
-            StreamTest[version].fromObjects([new gutil.File({
+            StreamTest[version].fromObjects([new Vinyl({
               path: 'bibabelula.foo',
               contents: null
             })])
@@ -82,7 +83,7 @@ describe('gulp-ttf2woff conversion', function() {
 
         it('should let non-ttf files pass through', function(done) {
 
-            StreamTest[version].fromObjects([new gutil.File({
+            StreamTest[version].fromObjects([new Vinyl({
               path: 'bibabelula.foo',
               contents: new Buffer('ohyeah')
             })])
@@ -141,7 +142,7 @@ describe('gulp-ttf2woff conversion', function() {
 
         it('should let non-ttf files pass through', function(done) {
 
-          StreamTest[version].fromObjects([new gutil.File({
+          StreamTest[version].fromObjects([new Vinyl({
             path: 'bibabelula.foo',
             contents: new Stream.PassThrough()
           })])
@@ -152,7 +153,8 @@ describe('gulp-ttf2woff conversion', function() {
             }
             assert.equal(objs.length, 1);
             assert.equal(objs[0].path, 'bibabelula.foo');
-            assert(objs[0].contents instanceof Stream.PassThrough);
+            assert(Cloneable.isCloneable(objs[0].contents));
+            assert(objs[0].contents._original instanceof Stream.PassThrough);
             done();
           }));
 


### PR DESCRIPTION
Since gulp-util has been deprecated, this PR replaces gulp-util with alternative individual modules. https://github.com/gulpjs/gulp-util